### PR TITLE
Add support for mac notifications and update the readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 geckodriver.log
 .idea/
-notifier-mac.py
+notifier-test.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+geckodriver.log
+.idea/
+notifier-mac.py

--- a/README.md
+++ b/README.md
@@ -17,37 +17,46 @@ Simple, quick to set up stock notification bot for Nvidia 3080 that I used to ge
 	-	twilioAuth
 	-	twilioSid
 3. pip install any dependencies you don't have
-	-  `pip install twilio`
+	- `pip install twilio`
 	- `pip install selenium`
 	- `pip install win10toast` (Windows 10 users only)
 ## How to Run
-
-### Windows
 
 ```
 python notifier.py
 ```
 
-### MacOS
+### MacOS Troubleshooting
 
-#### If Python 3 is installed as `python` on your path:
+Make sure you have `NOTIFY_MAC` in the config section set to true
+
+##### MacOS Python3 Info
+
+MacOS typically has Python 2 installed on the path as `python` by default. If you do not have Python 3 on your system, 
+the easiest way to install is to get it from HomeBrew (https://brew.sh/)
+
+Once you have brew installed, you can install Python 3 by running this:
 
 ```
-python notifier-mac.py
+brew install python3
 ```
 
-#### If Python 3 is installed as `python3` on your path:
+When installed in this way, you will normally need to run it as `python3` instead of `python` 
 
 ```
-python3 notifier-mac.py
+python3 notifier.py
 ```
 
-*Important* If you are using python3 then you will probably need to install your pip dependencies with pip3 instead of pip like so:
+You will also need to install your pip dependencies with pip3 instead of pip like so:
 
 ```
 pip3 install twilio
 ```
 
 Do this for all the pip dependencies
+
+##### MacOS Gecko Driver Security
+
+The first time you run this script on a mac, the system will prevent you from using the gecko driver.  To allow this, open System Preferences > Security and Privacy and under the general tab, click the button to allow geckodriver to be run.  You will need to run the script at least once before you can do this.  The first time you run the script after allowing geckodriver the script will crash again, but it will not crash after that. 
 
 ## Feel free to submit any PRs or issues!!  

--- a/README.md
+++ b/README.md
@@ -19,8 +19,35 @@ Simple, quick to set up stock notification bot for Nvidia 3080 that I used to ge
 3. pip install any dependencies you don't have
 	-  `pip install twilio`
 	- `pip install selenium`
-	- `pip install win10toast`
+	- `pip install win10toast` (Windows 10 users only)
 ## How to Run
-`python notifier.py`
+
+### Windows
+
+```
+python notifier.py
+```
+
+### MacOS
+
+#### If Python 3 is installed as `python` on your path:
+
+```
+python notifier-mac.py
+```
+
+#### If Python 3 is installed as `python3` on your path:
+
+```
+python3 notifier-mac.py
+```
+
+*Important* If you are using python3 then you will probably need to install your pip dependencies with pip3 instead of pip like so:
+
+```
+pip3 install twilio
+```
+
+Do this for all the pip dependencies
 
 ## Feel free to submit any PRs or issues!!  

--- a/notifier.py
+++ b/notifier.py
@@ -68,9 +68,9 @@ if NOTIFY_MAC:
     import os
 else:
     from win10toast import ToastNotifier
+    toast = ToastNotifier()
 
 ### END OF CONFIG SECTION -----------------------------------------------------
-
 
 options = Options()
 options.headless = True
@@ -83,7 +83,7 @@ def alert(url):
     print(url)
     webbrowser.open(url, new=1)
     if NOTIFY_MAC:
-        mac_alert("3080 IN STOCK", url)
+        mac_alert("{} IN STOCK".format(product), url)
     else:
         toast.show_toast("{} IN STOCK".format(product), url, duration=5, icon_path="icon.ico")
     if USE_TWILIO:
@@ -108,7 +108,7 @@ def mac_alert(title, text):
               osascript -e 'display notification "{}" with title "{}"'
               """.format(text, title))
     os.system('afplay /System/Library/Sounds/Glass.aiff')
-    os.system('say "3080 In Stock"')
+    os.system('say "{}"'.format(title))
     return
 
 def selenium_get(url):

--- a/notifier.py
+++ b/notifier.py
@@ -1,5 +1,4 @@
 from urllib.request import urlopen, Request
-from win10toast import ToastNotifier
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
 
@@ -33,6 +32,7 @@ The Value is a tuple of size 4 with the following values:
 
 USE_TWILIO = True
 USE_DISCORD = True
+NOTIFY_MAC = False
 
 urlKeyWords = {
     "https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/rtx-3080/" : ("https://api-prod.nvidia.com/direct-sales-shop/DR/products/en_us/USD/5438481700", False, GET_API, 'Nvidia 3080', ),
@@ -64,12 +64,16 @@ if USE_TWILIO:
     twilioAuth = '## INSERT TWILIO AUTH HERE ##'
     client = Client(twilioSid, twilioAuth)
 
+if NOTIFY_MAC:
+    import os
+else:
+    from win10toast import ToastNotifier
+
 ### END OF CONFIG SECTION -----------------------------------------------------
 
 
 options = Options()
 options.headless = True
-toast = ToastNotifier()
 driver = webdriver.Firefox(options=options, executable_path=firefoxWebdriverExecutablePath)
 numReloads = 0
 
@@ -78,7 +82,10 @@ def alert(url):
     print("{} IN STOCK".format(product))
     print(url)
     webbrowser.open(url, new=1)
-    toast.show_toast("{} IN STOCK".format(product), url, duration=5, icon_path="icon.ico")
+    if NOTIFY_MAC:
+        mac_alert("3080 IN STOCK", url)
+    else:
+        toast.show_toast("{} IN STOCK".format(product), url, duration=5, icon_path="icon.ico")
     if USE_TWILIO:
         message = client.messages.create(to=twilioToNumber, from_=twilioFromNumber, body=url)
     if USE_DISCORD:
@@ -95,6 +102,14 @@ def alert(url):
         else:
             print("Payload delivered successfully, code {}.".format(result.status_code))
     time.sleep(60)
+
+def mac_alert(title, text):
+    os.system("""
+              osascript -e 'display notification "{}" with title "{}"'
+              """.format(text, title))
+    os.system('afplay /System/Library/Sounds/Glass.aiff')
+    os.system('say "3080 In Stock"')
+    return
 
 def selenium_get(url):
     # for jsp sites


### PR DESCRIPTION
update readme with MacOS info

fix some imports, remove own path from gecko executable path

merge notifier-mac with notifier

fix twilio indentation

combine win10 and mac support into single script

add notifier-mac.py to gitignore, merge notifier-mac in to notifier

remove notivier-mac

remove os import, only needed if on mac

put back 60s sleep timer after notification is sent