### PR TITLE
Config option for opening a web browser, plus add geckodriver to gitignore

### DIFF
--- a/.env
+++ b/.env
@@ -22,3 +22,6 @@ ALERT_DELAY=60
 # Variable delay will be between these two values
 MIN_DELAY=3
 MAX_DELAY=12
+
+# Variable to decide if a web browser should open automatically (set to false if running on a headless server)
+OPEN_WEB_BROWSER="true"

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .env
 geckodriver.log
 notifier-test.py
-geckdriver
+geckodriver
 geckodriver.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.idea/
 .env
 geckodriver.log
-.idea/
 notifier-test.py
+geckdriver
+geckodriver.exe

--- a/notifier.py
+++ b/notifier.py
@@ -63,6 +63,7 @@ TWILIO_AUTH = getenv('TWILIO_AUTH')
 ALERT_DELAY = int(getenv('ALERT_DELAY'))
 MIN_DELAY = int(getenv('MIN_DELAY'))
 MAX_DELAY = int(getenv('MAX_DELAY'))
+OPEN_WEB_BROWSER = getenv('OPEN_WEB_BROWSER') == 'true'
 
 # Selenium Setup
 if WEBDRIVER_PATH:
@@ -100,7 +101,8 @@ def alert(url):
     product = url_keywords[url][3]
     print("{} IN STOCK".format(product))
     print(url)
-    webbrowser.open(url, new=1)
+    if OPEN_WEB_BROWSER:
+        webbrowser.open(url, new=1)
     os_notification("{} IN STOCK".format(product), url)
     sms_notification(url)
     discord_notification(product, url)


### PR DESCRIPTION
If running in a server terminal with a terminal browser installed (such as lynx) the program will open lynx in the terminal and halt execution