### PR TITLE
fix error breaking script when no test command provided

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -177,10 +177,13 @@ def nvidia_get(url, api_url):
 
 
 def is_test():
-    if sys.argv[1] == 'test':
-        alert("https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/rtx-3080/")
-        print("Test complete, if you received notification, you're good to go.")
-        return True
+    try:
+        if sys.argv[1] == 'test':
+            alert("https://www.nvidia.com/en-us/geforce/graphics-cards/30-series/rtx-3080/")
+            print("Test complete, if you received notification, you're good to go.")
+            return True
+    except:
+        return False
 
 def main():
     search_count = 0


### PR DESCRIPTION
Wrapped is_test in a try block to catch error if no argument is provided 